### PR TITLE
Added "--no-port-redir" parameter

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -488,7 +488,7 @@ int main(int argc, char *argv[])
     mobile_config_set_dns(mobile->adapter, &dns2, MOBILE_DNS2);
     mobile_config_set_p2p_port(mobile->adapter, p2p_port);
     mobile_config_set_relay(mobile->adapter, &relay);
-    mobile_config_alt_mail(mobile->adapter, change_mail_port);
+    mobile_config_set_alt_mail(mobile->adapter, change_mail_port);
 
     if (relay_token_update) {
         mobile_config_set_relay_token(mobile->adapter, relay_token);

--- a/source/main.c
+++ b/source/main.c
@@ -259,7 +259,7 @@ static void show_help_full(void)
         "--p2p_port port     Port to use for relay-less P2P communications\n"
         "--relay addr        Set relay server for P2P communications\n"
         "--relay-token hex   Set relay token (or empty to clear)\n"
-        "--alt_mail          Set the adapter to use port 587 during SMTP requests\n"
+        "--no-port-redir     Set the adapter to use port 25 during SMTP requests\n"
     );
     exit(EXIT_SUCCESS);
 }
@@ -342,7 +342,7 @@ int main(int argc, char *argv[])
     char *fname_config = "config.bin";
     enum mobile_adapter_device device = MOBILE_ADAPTER_BLUE;
     bool device_unmetered = false;
-    bool change_mail_port = false;
+    bool change_mail_port = true;
     struct mobile_addr dns1 = {0};
     struct mobile_addr dns2 = {0};
     unsigned dns_port = MOBILE_DNS_PORT;
@@ -416,8 +416,8 @@ int main(int argc, char *argv[])
                 show_help();
             }
             argv += 1;
-        } else if (strcmp(*argv, "--alt_mail") == 0) {
-            change_mail_port = true;
+        } else if (strcmp(*argv, "--no-port-redir") == 0) {
+            change_mail_port = false;
         } else {
             fprintf(stderr, "Unknown option: %s\n", *argv);
             show_help();
@@ -488,7 +488,6 @@ int main(int argc, char *argv[])
     mobile_config_set_dns(mobile->adapter, &dns2, MOBILE_DNS2);
     mobile_config_set_p2p_port(mobile->adapter, p2p_port);
     mobile_config_set_relay(mobile->adapter, &relay);
-
     mobile_config_alt_mail(mobile->adapter, change_mail_port);
 
     if (relay_token_update) {

--- a/source/main.c
+++ b/source/main.c
@@ -259,6 +259,7 @@ static void show_help_full(void)
         "--p2p_port port     Port to use for relay-less P2P communications\n"
         "--relay addr        Set relay server for P2P communications\n"
         "--relay-token hex   Set relay token (or empty to clear)\n"
+        "--alt_mail          Set the adapter to use port 587 during SMTP requests\n"
     );
     exit(EXIT_SUCCESS);
 }
@@ -341,6 +342,7 @@ int main(int argc, char *argv[])
     char *fname_config = "config.bin";
     enum mobile_adapter_device device = MOBILE_ADAPTER_BLUE;
     bool device_unmetered = false;
+    bool change_mail_port = false;
     struct mobile_addr dns1 = {0};
     struct mobile_addr dns2 = {0};
     unsigned dns_port = MOBILE_DNS_PORT;
@@ -414,6 +416,8 @@ int main(int argc, char *argv[])
                 show_help();
             }
             argv += 1;
+        } else if (strcmp(*argv, "--alt_mail") == 0) {
+            change_mail_port = true;
         } else {
             fprintf(stderr, "Unknown option: %s\n", *argv);
             show_help();
@@ -484,6 +488,9 @@ int main(int argc, char *argv[])
     mobile_config_set_dns(mobile->adapter, &dns2, MOBILE_DNS2);
     mobile_config_set_p2p_port(mobile->adapter, p2p_port);
     mobile_config_set_relay(mobile->adapter, &relay);
+
+    mobile_config_alt_mail(mobile->adapter, change_mail_port);
+
     if (relay_token_update) {
         mobile_config_set_relay_token(mobile->adapter, relay_token);
     }


### PR DESCRIPTION
This PR creates a dependency with this another one https://github.com/REONTeam/libmobile/pull/14

The idea is to add a parameter called "--alt_mail" (or any other name) to force the adapter to use port 587 instead port 25 for SMTP communication. This should solve some issues with some ISP that blocks port 25 (like mine)

However, the server MUST run the email server on port 587 as well.

-------------------

Tested on Lubuntu only... didn't have Windows installed to compile an .exe :(